### PR TITLE
194 bug tela de vitoria funcionando

### DIFF
--- a/Autoload/AchievementsManager.gd
+++ b/Autoload/AchievementsManager.gd
@@ -11,7 +11,7 @@ var achievements = {
 			 o quilombo por 20 dias desafiadores.",
 			# ADICIONADO: Descrição de objetivo
 			"locked_tooltip": "Sobreviva por 20 dias.",
-			"icon": "res://Assets/Sprites/Exported/HUD/Icons/sururu-icon.png"
+			"icon": "res://Assets/Sprites/Exported/HUD/Icons/star-on-icon.png"
 		}
 	},
 	"liberate_10_npcs": {

--- a/Autoload/GameManager.gd
+++ b/Autoload/GameManager.gd
@@ -3,7 +3,7 @@ extends Node
 
 enum LeaderType { PACIFISTA, AGRICULTOR, GUERREIRO, LIVRE }
 
-const DAYS_TO_WIN: int = 1
+const DAYS_TO_WIN: int = 30
 var npcs_liberados: int = 0
 const NPCS_PARA_VITORIA: int = 20
 @export var victory_screen_scene: PackedScene = preload("res://Scenes/UI/victory.tscn")

--- a/Autoload/GameManager.gd
+++ b/Autoload/GameManager.gd
@@ -3,7 +3,7 @@ extends Node
 
 enum LeaderType { PACIFISTA, AGRICULTOR, GUERREIRO, LIVRE }
 
-const DAYS_TO_WIN: int = 30
+const DAYS_TO_WIN: int = 1
 var npcs_liberados: int = 0
 const NPCS_PARA_VITORIA: int = 20
 @export var victory_screen_scene: PackedScene = preload("res://Scenes/UI/victory.tscn")
@@ -104,17 +104,21 @@ func _on_new_day_started(day_number: int):
 		# Agora chama a função com o tipo correto.
 		_trigger_victory("survival")
 		
-func _trigger_victory(victory_type: String = "survival"): # "survival" é o padrão
-	if _is_game_over: return
+func _trigger_victory(victory_type: String = "survival"):
+	if _is_game_over: 
+		return
 	_is_game_over = true
 	
 	print("VITÓRIA! O jogador venceu por: ", victory_type)
-	pause_game()
-	
+
 	var victory_screen = victory_screen_scene.instantiate()
-	add_child(victory_screen)
-	if victory_screen.has_method("set_victory_type"):
-		victory_screen.set_victory_type(victory_type)
+	get_tree().root.add_child(victory_screen)
+
+	emit_signal("victory_achieved")
+	pause_game()
+
+
+
 
 # ADICIONADO: Função central que lida com a derrota.
 func trigger_defeat(reason: String):

--- a/Autoload/QuilomboManager.gd
+++ b/Autoload/QuilomboManager.gd
@@ -27,9 +27,14 @@ func register_npc(npc: NPC):
 		all_npcs.append(npc)
 		npc_count_changed.emit(all_npcs.size())
 
+		# 🔑 Checa conquista aqui
+		if all_npcs.size() >= 10:
+			AchievementsManager.check_and_unlock("liberate_10_npcs")
+
 		var hud = get_tree().get_first_node_in_group("hud_main")
 		if is_instance_valid(hud):
 			npc.npc_clicked.connect(hud.show_npc_inspector)
+
 
 func register_building(building_node):
 	var type = building_node.scene_file_path


### PR DESCRIPTION
Tela de vitoria funcionando e aparecendo junto com as conquistas desbloqueadas, faltou um emit_signal para que a tela de vitoria aparecesse e no QuilomboManager,gd na function register_npc, ele pega o tamanho total de all_npcs e caso tenha chegado em 10 ele libera a conquista na tela de vitoria mostrando que o jogador obteve a conquista